### PR TITLE
Adding a keyboard cue to the shockwave demo caption

### DIFF
--- a/godot/Demos/Shockwave3DDemo.tscn
+++ b/godot/Demos/Shockwave3DDemo.tscn
@@ -19,6 +19,6 @@ __meta__ = {
 visible = false
 
 [node name="DemoInterface" parent="." instance=ExtResource( 3 )]
-text_bbcode = "Uses a vertex shader to propagate a spherical shockwave through the geometry, instead of as a post-process effect."
+text_bbcode = "Press Enter to launch a shockwave. Uses a vertex shader to propagate a spherical shockwave through the geometry, instead of as a post-process effect."
 
 [editable path="Demo3DEnvironment"]


### PR DESCRIPTION
I was waiting for the shockwave example to happen (since most of the demos are automatic) but you have to press Enter to make it start. This was not present on the label so I just modified that and added "Press Enter to launch a shockwave."
Feel free to reject it and re-write it in whatever form you like, just wanted to be proactive  😄 

Love the shaders and thanks for the amazing repo!
