### PR TITLE
Fix duplicate shader_type error

### DIFF
--- a/godot/Shaders/interactive_snow.gdshader
+++ b/godot/Shaders/interactive_snow.gdshader
@@ -1,7 +1,5 @@
 shader_type spatial;
 
-shader_type spatial;
-
 group_uniforms Snow;
 /** Mask texture for the snow and dirt mix. This is the texture to which the game writes the ball trail. */
 uniform sampler2D mask_texture: hint_default_white, repeat_disable, filter_linear_mipmap;


### PR DESCRIPTION
Removed duplicate shader_type declaration.

Found while reading gdshaders.